### PR TITLE
Rename method

### DIFF
--- a/AsyncContainer.hpp
+++ b/AsyncContainer.hpp
@@ -22,7 +22,7 @@ namespace DataIO::Container
 	public:
 		AsyncContainer()noexcept;
 		void Throw(Data_t&& InputImage) noexcept;
-		bool Recive(const std::chrono::milliseconds timeout, LpDataObject& GetImage) noexcept;
+		bool Recieve(const std::chrono::milliseconds timeout, LpDataObject& GetImage) noexcept;
 	};
 
 	template<typename Data_t, template<typename FutureType> typename Future_t>
@@ -81,7 +81,7 @@ namespace DataIO::Container
 	}
 	template<typename Data_t, template<typename FutureType> typename Future_t>
 	[[nodiscard]]
-	inline bool AsyncContainer<Data_t, Future_t>::Recive(const std::chrono::milliseconds timeout, LpDataObject& GetData) noexcept
+	inline bool AsyncContainer<Data_t, Future_t>::Recieve(const std::chrono::milliseconds timeout, LpDataObject& GetData) noexcept
 	{
 		OutputUpdate(timeout);
 		{

--- a/AsyncContainer.hpp
+++ b/AsyncContainer.hpp
@@ -11,11 +11,11 @@ namespace DataIO::Container
 		LpDataObject MakePointer(const Data_t& Input=Data_t{}) { return std::make_shared<Data_t>(Input); }
 
 		// ”ñ“¯Šú‘—M
-		std::unique_ptr<std::promise<LpDataObject>> Promise;
+		std::unique_ptr<std::promise<LpDataObject>> m_Promise;
 		// ”ñ“¯ŠúóM
 		std::future<LpDataObject> m_UniqueFuture;
 		// ”ñ“¯ŠúóMŒ‹‰Ê‚ğ•Û‘¶
-		std::shared_future<LpDataObject> SharedGetter;
+		std::shared_future<LpDataObject> m_SharedFuture;
 
 		void InputUpdate(Data_t&& InputImage) noexcept;
 		void OutputUpdate(const std::chrono::milliseconds timeout)   noexcept;

--- a/AsyncContainer.hpp
+++ b/AsyncContainer.hpp
@@ -17,10 +17,10 @@ namespace DataIO::Container
 		// ”ñ“¯ŠúóMŒ‹‰Ê‚ğ•Û‘¶
 		std::shared_future<LpDataObject> m_SharedFuture;
 
-		void InputUpdate(Data_t&& InputImage) noexcept;
+		void UpdateInput(Data_t&& InputImage) noexcept;
 
 		template<typename DataType,typename Ratio>
-		void OutputUpdate(const std::chrono::duration<DataType,Ratio>& Timeout)   noexcept;
+		void UpdateOutput(const std::chrono::duration<DataType,Ratio>& Timeout)   noexcept;
 	public:
 		AsyncContainer()noexcept;
 		void Throw(Data_t&& InputImage) noexcept;

--- a/AsyncContainer.hpp
+++ b/AsyncContainer.hpp
@@ -28,7 +28,6 @@ namespace DataIO::Container
 		template<typename DataType,typename Ratio >
 		bool Recieve(const std::chrono::duration<DataType,Ratio>& timeout, LpDataObject& GetImage) noexcept;
 
-	//	bool Recieve(const std::chrono::milliseconds timeout, LpDataObject& GetImage) noexcept;
 	};
 
 	template<typename Data_t>
@@ -40,7 +39,7 @@ namespace DataIO::Container
 		this->m_Promise->set_value(LpDataObject{});
 	}
 	template<typename Data_t>
-	inline void AsyncContainer<Data_t>::InputUpdate(Data_t&& InputImage) noexcept
+	inline void AsyncContainer<Data_t>::UpdateInput(Data_t&& InputImage) noexcept
 	{
 		if (!this->m_UniqueFuture.valid())
 		{
@@ -54,13 +53,13 @@ namespace DataIO::Container
 	inline void AsyncContainer<Data_t>::Throw(Data_t&& InputImage) noexcept
 	{
 		try {
-			InputUpdate(std::forward<Data_t>(InputImage));
+			this->UpdateInput(std::forward<Data_t>(InputImage));
 		}
 		catch (const std::future_error & e)
 		{
 			if (e.code() != std::future_errc::promise_already_satisfied)
 			{
-				ASSERT(0);
+				assert(0);
 			}
 
 		}
@@ -102,13 +101,13 @@ namespace DataIO::Container
 	}*/
 	template<typename Data_t>
 	template<typename DataType, typename Ratio>
-	inline void AsyncContainer<Data_t>::OutputUpdate(const std::chrono::duration<DataType, Ratio>& Timeout) noexcept
+	inline void AsyncContainer<Data_t>::UpdateOutput(const std::chrono::duration<DataType, Ratio>& Timeout) noexcept
 	{
 
 		try {
 			if (this->m_UniqueFuture.valid())
 			{
-				auto Result = this->m_UniqueFuture.wait_for(timeout);
+				auto Result = this->m_UniqueFuture.wait_for(Timeout);
 				if (Result != std::future_status::timeout)
 				{
 					this->m_SharedFuture = this->m_UniqueFuture.share();
@@ -126,7 +125,7 @@ namespace DataIO::Container
 	template<typename DataType,typename Ratio >
 	[[nodiscard]] inline bool AsyncContainer<Data_t>::Recieve(const std::chrono::duration<DataType, Ratio>& timeout, LpDataObject& GetImage) noexcept
 	{
-		OutputUpdate(timeout);
+		this->UpdateOutput(timeout);
 
 		if (this->m_SharedFuture.get())
 		{

--- a/AsyncContainer.hpp
+++ b/AsyncContainer.hpp
@@ -1,8 +1,13 @@
 #pragma once
 #include <future>
 #include <iostream>
+#if __has_include(<concepts>)
+#include <concepts>
+#endif
 namespace DataIO::Container
 {
+	
+
 	template<typename Data_t>
 	class AsyncContainer
 	{
@@ -123,9 +128,9 @@ namespace DataIO::Container
 	}
 	template<typename Data_t>
 	template<typename DataType,typename Ratio >
-	[[nodiscard]] inline bool AsyncContainer<Data_t>::Recieve(const std::chrono::duration<DataType, Ratio>& timeout, LpDataObject& GetImage) noexcept
+	[[nodiscard]] inline bool AsyncContainer<Data_t>::Recieve(const std::chrono::duration<DataType, Ratio>& Timeout, LpDataObject& GetImage) noexcept
 	{
-		this->UpdateOutput(timeout);
+		this->UpdateOutput(Timeout);
 
 		if (this->m_SharedFuture.get())
 		{


### PR DESCRIPTION
リファクタリングした

# refactoring 
* メソッド名を統一した
* 無駄なテンプレート引数を削除
* 時間をmilisecond 以外にも対応できるようにした
